### PR TITLE
Drop HTTPX dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,6 @@ Each entry contains:
 ## Requirements
 
 - Python 3.7+
-- httpx
 - lxml
 - parsedatetime
 - python-dateutil

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,7 +31,6 @@ package_dir =
 packages = find:
 python_requires = >=3.7
 install_requires =
-    httpx
     lxml
     parsedatetime
     python-dateutil

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,6 +16,8 @@ classifiers =
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
+    Programming Language :: Python :: 3.12
+    Programming Language :: Python :: 3.13
     License :: OSI Approved :: MIT License
     Operating System :: OS Independent
     Development Status :: 4 - Beta

--- a/src/fastfeedparser/main.py
+++ b/src/fastfeedparser/main.py
@@ -44,7 +44,7 @@ def parse(source):
         HTTPError: If URL fetch fails
     """
     # Handle URL input
-    if isinstance(source, str) and (source.startswith(('http://', 'https://'))):
+    if isinstance(source, str) and source.startswith(('http://', 'https://')):
         request = Request(
             source,
             method='GET',


### PR DESCRIPTION
> Minimal dependencies

In the spirit of simplicity, I noticed that HTTPX dependency is mostly redundant here. I have implemented GET fetching in stdlib Python with support for redirects, bad status codes, and compression. I have also added a distinguishable User-Agent header.