### PR TITLE
Remove empty feed exception

### DIFF
--- a/src/fastfeedparser/main.py
+++ b/src/fastfeedparser/main.py
@@ -134,15 +134,6 @@ def parse(source: str | bytes) -> FastFeedParserDict:
             # Try finding entries without namespace if none found
             items = root.findall(".//entry") 
             
-        if not items:
-            nsmap = getattr(root, 'nsmap', {})
-            default_ns = nsmap.get(None, '')
-            xmlns = root.get('xmlns', '')
-            
-            raise ValueError(
-                f"Feed tag 'feed' found but no entries found. "
-                f"Found namespaces - default: {default_ns}, xmlns: {xmlns}"
-            )
     elif root_tag == "rdf":
         feed_type = "rdf"
         channel = root

--- a/tests/integration/cgpplay.json
+++ b/tests/integration/cgpplay.json
@@ -1,0 +1,17 @@
+{
+  "entries": [],
+  "feed": {
+    "author": "CGP Play",
+    "id": "yt:channel:zSBv-iml0SCoAE-6v2ReWQ",
+    "language": null,
+    "link": "http://www.youtube.com/feeds/videos.xml?channel_id=UCzSBv-iml0SCoAE-6v2ReWQ",
+    "links": [
+      {
+        "href": "https://www.youtube.com/channel/UCzSBv-iml0SCoAE-6v2ReWQ",
+        "rel": "alternate",
+        "title": null,
+        "type": null
+      }
+    ]
+  }
+}

--- a/tests/integration/cgpplay.xml
+++ b/tests/integration/cgpplay.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<feed xmlns:yt="http://www.youtube.com/xml/schemas/2015" xmlns:media="http://search.yahoo.com/mrss/" xmlns="http://www.w3.org/2005/Atom">
+ <link rel="self" href="http://www.youtube.com/feeds/videos.xml?channel_id=UCzSBv-iml0SCoAE-6v2ReWQ"/>
+ <id>yt:channel:zSBv-iml0SCoAE-6v2ReWQ</id>
+ <yt:channelId>zSBv-iml0SCoAE-6v2ReWQ</yt:channelId>
+ <title>CGP Play</title>
+ <link rel="alternate" href="https://www.youtube.com/channel/UCzSBv-iml0SCoAE-6v2ReWQ"/>
+ <author>
+  <name>CGP Play</name>
+  <uri>https://www.youtube.com/channel/UCzSBv-iml0SCoAE-6v2ReWQ</uri>
+ </author>
+ <published>2015-09-17T13:42:57+00:00</published>
+</feed>


### PR DESCRIPTION
#7 was not resolved by #8, but it looks like Kagi agrees that parsing a feed without items should not raise an exception. This pull request implements this, and adds a test case to ensure that an empty feed is parsed without a ValueError being raised.