### PR TITLE
Update date parsing dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,8 +139,8 @@ Each entry contains:
 ## Requirements
 
 - Python 3.7+
+- dateparser
 - lxml
-- parsedatetime
 - python-dateutil
 
 ## Contributing

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,8 +31,8 @@ package_dir =
 packages = find:
 python_requires = >=3.7
 install_requires =
+    dateparser
     lxml
-    parsedatetime
     python-dateutil
 
 [options.packages.find]


### PR DESCRIPTION
The recent changes to datetime parsing mean fastfeedparser now depends on dateparser instead of parsedatetime. This PR updates the fastfeedparser dependencies to reflect this change.