### PR TITLE
Try to get the element value from rdf as fallback

### DIFF
--- a/src/fastfeedparser/main.py
+++ b/src/fastfeedparser/main.py
@@ -585,6 +585,7 @@ def _field_value_getter(
                 )
                 if is_attr
                 else _get_element_value(root, atom_css)
+                or _get_element_value(root, rdf_css)
             )
 
     elif feed_type == "atom":


### PR DESCRIPTION
In some cases, like with the SPIP generator, you have mixed xmlns declarations (see https://www.spip.net/spip.php?page=backend source for instance)

Without that fix, we are not able to retrieve the `published` item date from the `<dc:date>` tag.